### PR TITLE
Removing type param from authenticate function

### DIFF
--- a/library/Zend/Auth/Adapter/Facebook.php
+++ b/library/Zend/Auth/Adapter/Facebook.php
@@ -107,7 +107,6 @@ class Zend_Auth_Adapter_Facebook implements Zend_Auth_Adapter_Interface
         $args = array(
             'client_id'     => $this->_appId,
             'client_secret' => $this->_secret,
-            'type'          => 'client_cred',
             'redirect_uri'  => $this->getRedirectUri(),
             'code'          => $this->_token,
         );


### PR DESCRIPTION
The type param is not necessary for authenticating the user in the OAuth
"dance". Including it in this portion produces an access token that does
not give access to https://graph.facebook.com/me/.  

Source: http://stackoverflow.com/questions/2838396/facebook-graph-api-authorization-types
