### PR TITLE
Drop query parameter "code" while rebuilding the current URL

### DIFF
--- a/library/Zend/Auth/Adapter/Facebook.php
+++ b/library/Zend/Auth/Adapter/Facebook.php
@@ -42,6 +42,7 @@ class Zend_Auth_Adapter_Facebook implements Zend_Auth_Adapter_Interface
     protected static $DROP_QUERY_PARAMS = array(
         'session',
         'signed_request',
+        'code'
     );
 
     /**


### PR DESCRIPTION
so Facebook doesn't complain about "Error validating verification code" when used as redirect_uri
